### PR TITLE
Added complete test suite

### DIFF
--- a/src/check_cmake/checks.py
+++ b/src/check_cmake/checks.py
@@ -358,7 +358,8 @@ class SpecifyMinimumCMakeVersion(Check):
                 ),
             )
 
-
+# minor issue here that this detects only the first target_include_directories, it may find more on subsequent runs
+# after fixing the first one
 class TargetIncludeDirectoriesSYSTEM(Check):
     def __init__(self):
         super().__init__(

--- a/test-check-cmake.py
+++ b/test-check-cmake.py
@@ -1,14 +1,11 @@
+# to run this tester script:
+# virtualenv test_env
+# source test_env/bin/activate
+# pip install misk>=0.8.1 colorama
+
 import argparse
 import os
 import sys
-
-# Quick instruction to run this tester script:
-# virtualenv test_env
-# source test_env/bin/activate
-#
-# dependencies through check-cmake: ['misk >= 0.8.1', 'colorama']
-# In order to use it: pip install misk>=0.8.1 colorama
-# The code generator tool and library versions need to match.
 from src.check_cmake.main import main_internal
 
 def run_test(full_test_dir, expect_error):
@@ -16,14 +13,15 @@ def run_test(full_test_dir, expect_error):
 
     result = main_internal()
     if result != 0:
-        print(f"Found an expected error in {full_test_dir}: {result}")
+        print(f"Found an expected error(s) in {full_test_dir}: {result}")
 
+    # could be wisened up to check error counts
     if expect_error == True and result == 0:
-        print(f"Expected an error in {full_test_dir}, but got none.")
+        print(f"Expected an error(s) in {full_test_dir}, but got none.")
         sys.exit(-1)
 
     if expect_error == False and result != 0:
-        print(f"Expected no error in {full_test_dir}, but got one.")
+        print(f"Expected no error(s) in {full_test_dir}, but got some.")
         sys.exit(-1)
 
 def run_suite(testdir_root, expect_error):

--- a/tests/error/externalproject/CMakeLists.txt
+++ b/tests/error/externalproject/CMakeLists.txt
@@ -1,0 +1,5 @@
+ExternalProject_Add(
+    some_lib
+    SOURCE_DIR "some_lib/source"
+    CMAKE_ARGS -D CMAKE_BUILD_TYPE=Release
+)

--- a/tests/error/library_type/CMakeLists.txt
+++ b/tests/error/library_type/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(my_lib)
+
+add_library(${my_library})

--- a/tests/error/target_include_directories/CMakeLists.txt
+++ b/tests/error/target_include_directories/CMakeLists.txt
@@ -1,0 +1,7 @@
+target_include_directories(
+    my_lib 
+    PRIVATE 
+        "some/path"
+    SYSTEM 
+        "$<INSTALL_INTERFACE:include>)"
+}

--- a/tests/error/target_include_directories_var/CMakeLists.txt
+++ b/tests/error/target_include_directories_var/CMakeLists.txt
@@ -1,0 +1,7 @@
+target_include_directories(
+    ${my_lib} 
+    PRIVATE 
+        "some/path"
+    SYSTEM 
+        "$<INSTALL_INTERFACE:include>)"
+}

--- a/tests/error/target_recommended/CMakeLists.txt
+++ b/tests/error/target_recommended/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_compile_options(my_app PRIVATE -Wall)
+set_target_properties(my_app PROPERTIES CXX_STANDARD 17)
+add_compile_definitions(my_app PRIVATE DEBUG=1)
+include_directories(my_app PRIVATE "some/include/path")
+link_directories(my_app PRIVATE "some/lib/path")
+
+add_compile_options(${my_app} PRIVATE -Wall)
+set_target_properties(${my_app} PROPERTIES CXX_STANDARD 17)
+add_compile_definitions(${my_app} PRIVATE DEBUG=1)
+include_directories(${my_app} PRIVATE "some/include/path")
+link_directories(${my_app} PRIVATE "some/lib/path")
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/tests/error/test_target_include_directories/CMakeLists.txt
+++ b/tests/error/test_target_include_directories/CMakeLists.txt
@@ -1,3 +1,0 @@
-target_include_directories(
-    ${project_lib}
-)

--- a/tests/error/threads/CMakeLists.txt
+++ b/tests/error/threads/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_link_libraries(my_app PRIVATE pthread)
+
+target_link_libraries(${my_app} PRIVATE pthread)

--- a/tests/error/version/CMakeLists.txt
+++ b/tests/error/version/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(
+    PROJECT-NAME
+    VERSION 1
+)
+
+project(
+    PROJECT-NAME
+)
+
+project(
+    ${PROJECT-NAME}
+)

--- a/tests/valid/externalproject/CMakeLists.txt
+++ b/tests/valid/externalproject/CMakeLists.txt
@@ -1,0 +1,5 @@
+ExternalProject_Add(
+    some_lib
+    SOURCE_DIR "some_lib/source"
+    CMAKE_ARGS "-DCMAKE_BUILD_TYPE=Release"
+)

--- a/tests/valid/library_type/CMakeLists.txt
+++ b/tests/valid/library_type/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(my_library STATIC)
+
+add_library(${my_library} SHARED)

--- a/tests/valid/target_include_directories/CMakeLists.txt
+++ b/tests/valid/target_include_directories/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_include_directories(
+    project_lib
+    SYSTEM
+    INTERFACE
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+)

--- a/tests/valid/target_include_directories_var/CMakeLists.txt
+++ b/tests/valid/target_include_directories_var/CMakeLists.txt
@@ -1,14 +1,4 @@
 target_include_directories(
-    project_lib
-    SYSTEM
-    INTERFACE
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-
-    PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-)
-
-target_include_directories(
     ${project_lib}
     SYSTEM
     INTERFACE

--- a/tests/valid/threads/CMakeLists.txt
+++ b/tests/valid/threads/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_link_libraries(my_app PUBLIC Threads::Threads)
+
+target_link_libraries(${my_app} PUBLIC Threads::Threads)

--- a/tests/valid/version/CMakeLists.txt
+++ b/tests/valid/version/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(
+    PROJECT-NAME
+    VERSION 1
+)
+
+project(
+    ${PROJECT-NAME}
+    VERSION 1
+)

--- a/tests/valid/version_no_check/CMakeLists.txt
+++ b/tests/valid/version_no_check/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(
+    PROJECT-NAME # nocheck
+)


### PR DESCRIPTION
Covers most if not all of check-cmake functionality. Could be wisened up to count specific amount of errors expected for each test directory. But this is already an improvement and decent protection against regressions.

And of course trivially testable new features when they are added.